### PR TITLE
Move Open Teams-specific styles after main icon styles & fix word

### DIFF
--- a/doc/_static/css/custom_styles.css
+++ b/doc/_static/css/custom_styles.css
@@ -21,20 +21,6 @@ strong {
 
 /* Style for Font Awesome that only styles the icons before elements */
 
-
-/* Style for OpenTeams icon, used like the FA Brands icons */
-
-.openteams-icon::before {
-  content: url("../images/openteams-favicon.svg");
-  margin-left: -0.2em;
-  width: 1.3em;
-}
-
-div.openteams-icon::before {
-  margin-right: 0;
-  padding-bottom: 0;
-}
-
 .fasb::before,
 .fabb::before {
   color: #36557c;
@@ -109,6 +95,19 @@ div.fa-globe-americas::before {
 
 div.fa-user-friends::before {
   color: #f6951f;
+}
+
+/*** Style for OpenTeams icon, used like the FA Brands icons ***/
+
+.openteams-icon::before {
+  content: url("../images/openteams-favicon.svg");
+  margin-left: -0.2em;
+  width: 1.3em;
+}
+
+div.openteams-icon::before {
+  margin-right: 0;
+  padding-bottom: 0;
 }
 
 /*** Changes to the FAQ page ***/

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -351,7 +351,7 @@ Additional help
 
 .. rst-class:: fasb openteams-icon
 
-*Need personalized help from expert Spyder consultants?* Visit `OpenTeams`_.
+*Seeking personalized help from expert Spyder consultants?* Visit `OpenTeams`_.
 
 .. _Troubleshooting Guide and FAQ: https://github.com/spyder-ide/spyder/wiki/Troubleshooting-Guide-and-FAQ
 .. _main website: https://www.spyder-ide.org/


### PR DESCRIPTION
This implements the style fix I couldn't make as a suggestion, plus fixes one word that was my mistake initially. See [my review](https://github.com/spyder-ide/spyder-docs/pull/310#pullrequestreview-917935593).